### PR TITLE
Improve event tracking UI and add basic API

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+
+interface Event {
+  id: string
+  date: string
+  name: string
+  importance: number
+  content: string
+  daysRemaining: number
+  totalDays?: number
+  isEditing: boolean
+}
+
+let events: Event[] = []
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const id = searchParams.get('id')
+  if (id) {
+    const event = events.find((e) => e.id === id)
+    if (event) return NextResponse.json(event)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(events)
+}
+
+export async function POST(request: Request) {
+  const { action, event, id } = await request.json()
+  switch (action) {
+    case 'add':
+      events.push(event)
+      break
+    case 'edit':
+      events = events.map((e) => (e.id === event.id ? { ...e, ...event } : e))
+      break
+    case 'delete':
+      events = events.filter((e) => e.id !== (id || event?.id))
+      break
+    default:
+      break
+  }
+  return NextResponse.json({ ok: true })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,6 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
 import "./globals.css"
-
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-})
 
 export const metadata: Metadata = {
   title: "Sistema de Seguimiento de Eventos",
@@ -21,7 +14,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="es" className={`${inter.variable} antialiased`}>
+    <html lang="es" className="antialiased">
       <body className="font-sans">{children}</body>
     </html>
   )


### PR DESCRIPTION
## Summary
- Replace settings button with info toggle and display full weekday names
- Add local storage permissions, progress bars for theory and practice, and overall progress metrics
- Provide API route supporting GET and POST actions for events

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c988f4e1083308253f4e4d2a4efef