### PR TITLE
Implement scheduling endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Seguimiento API
+
+This project now exposes two endpoints to assist with study planning:
+
+- `POST /api/next`: receives `{ slotMinutes, currentTrackSlug?, forceSwitch? }` and
+  returns the next recommended track to study. Responds with `204` when there are
+  no pending tracks.
+- `POST /api/progress`: receives `{ trackSlug, minutesSpent?, nextIndex? }` to
+  register completed work on a track and returns the updated track along with the
+  next suggestion.
+
+Each suggestion includes the planned acts and minutes together with a reason and
+diagnostic values (`Δ, D, R, cuota, score`) that follow the scheduling rules.

--- a/app/api/next/route.ts
+++ b/app/api/next/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getNextSuggestion } from "../../../lib/scheduler";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { slotMinutes, currentTrackSlug, forceSwitch } = body;
+  const result = getNextSuggestion({
+    slotMinutes: slotMinutes ?? 50,
+    currentTrackSlug,
+    forceSwitch,
+  });
+  if (!result) return new Response(null, { status: 204 });
+  return NextResponse.json(result);
+}

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { registerProgress, getNextSuggestion } from "../../../lib/scheduler";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { trackSlug, minutesSpent, nextIndex } = body;
+  const updatedTrack = registerProgress(trackSlug, minutesSpent, nextIndex);
+  if (!updatedTrack) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  const suggestedNext = getNextSuggestion({
+    slotMinutes: minutesSpent ?? updatedTrack.avgMinPerAct,
+    currentTrackSlug: trackSlug,
+    forceSwitch: false,
+  });
+  return NextResponse.json({ updatedTrack, suggestedNext });
+}

--- a/lib/dayStats.ts
+++ b/lib/dayStats.ts
@@ -1,0 +1,30 @@
+import { Subject } from "./tracks";
+
+export interface DayStats {
+  date: string; // YYYY-MM-DD
+  actsToday: Record<string, number>;
+  minutesToday: Record<Subject, number>;
+}
+
+export const dayStats: DayStats = {
+  date: new Date().toISOString().slice(0, 10),
+  actsToday: {},
+  minutesToday: {
+    "Álgebra": 0,
+    "Cálculo": 0,
+    POO: 0,
+  },
+};
+
+export function resetDayIfNeeded() {
+  const today = new Date().toISOString().slice(0, 10);
+  if (dayStats.date !== today) {
+    dayStats.date = today;
+    dayStats.actsToday = {};
+    dayStats.minutesToday = {
+      "Álgebra": 0,
+      "Cálculo": 0,
+      POO: 0,
+    };
+  }
+}

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,0 +1,175 @@
+import { tracks, Track, Subject } from "./tracks";
+import { dayStats, resetDayIfNeeded } from "./dayStats";
+
+const B = 50; // cobertura mínima por materia
+const CMAX = 0.6; // 60%
+const PRACTICE_WINDOW_H = 48; // ventana de práctica
+
+function daysUntil(dateStr: string): number {
+  const today = new Date();
+  const target = new Date(dateStr);
+  const diff = Math.ceil((target.getTime() - today.getTime()) / 86400000);
+  return diff <= 0 ? 1 : diff;
+}
+
+function eventBonus(D: number): number {
+  if (D <= 1) return 1; // fuerte ≤24h
+  if (D <= 3) return 0.5; // moderado ≤72h
+  return 0;
+}
+
+function cooldownBonus(lastTouched: number): number {
+  if (!lastTouched) return 0.1;
+  const days = (Date.now() - lastTouched) / 86400000;
+  return days * 0.01;
+}
+
+interface SuggestParams {
+  slotMinutes: number;
+  currentTrackSlug?: string;
+  forceSwitch?: boolean;
+}
+
+export function getNextSuggestion(params: SuggestParams) {
+  resetDayIfNeeded();
+  const { slotMinutes, currentTrackSlug, forceSwitch } = params;
+
+  // compromiso de bloque
+  if (currentTrackSlug && !forceSwitch) {
+    const current = tracks.find((t) => t.slug === currentTrackSlug);
+    if (current && current.active && current.R > 0) {
+      const emergency = tracks.some(
+        (t) => t.slug !== currentTrackSlug && t.active && t.R > 0 && daysUntil(t.classDate) <= 1,
+      );
+      if (!emergency) {
+        const D = daysUntil(current.classDate);
+        const Q = Math.ceil(current.R / D);
+        const H = dayStats.actsToday[current.slug] || 0;
+        const delta = Q - H;
+        const pressure = current.R / D + eventBonus(D) + cooldownBonus(current.lastTouched);
+        return buildSuggestion(current, slotMinutes, `Materia ${current.subject} · continuar bloque · clase en ${D} días`, {
+          delta,
+          D,
+          R: current.R,
+          cuota: Q,
+          score: pressure,
+        });
+      }
+    }
+  }
+
+  let candidates = tracks.filter((t) => t.active && t.R > 0);
+  if (candidates.length === 0) return null;
+
+  const subjectDeficits: Record<Subject, number> = {
+    "Álgebra": Math.max(0, B - dayStats.minutesToday["Álgebra"]),
+    "Cálculo": Math.max(0, B - dayStats.minutesToday["Cálculo"]),
+    POO: Math.max(0, B - dayStats.minutesToday.POO),
+  };
+  const maxDeficit = Math.max(...Object.values(subjectDeficits));
+  let coverageSubjects: Subject[] = [];
+  if (maxDeficit > 0) {
+    coverageSubjects = (Object.keys(subjectDeficits) as Subject[]).filter(
+      (s) => subjectDeficits[s] === maxDeficit,
+    );
+    candidates = candidates.filter((t) => coverageSubjects.includes(t.subject));
+  }
+
+  const evaluated = candidates.map((t) => {
+    const D = daysUntil(t.classDate);
+    const Q = Math.ceil(t.R / D);
+    const H = dayStats.actsToday[t.slug] || 0;
+    const delta = Q - H;
+    const pressure = t.R / D + eventBonus(D) + cooldownBonus(t.lastTouched);
+    return { t, D, Q, H, delta, pressure };
+  });
+
+  const totalMinutes = Object.values(dayStats.minutesToday).reduce((a, b) => a + b, 0);
+  const overCmax: Subject[] = [];
+  if (totalMinutes > 0) {
+    (Object.keys(dayStats.minutesToday) as Subject[]).forEach((s) => {
+      if (dayStats.minutesToday[s] / totalMinutes > CMAX) overCmax.push(s);
+    });
+  }
+
+  const candidates2 = evaluated.filter((e) => {
+    if (overCmax.includes(e.t.subject) && !(e.D <= 1 && e.t.R > 0)) {
+      return false;
+    }
+    return true;
+  });
+  if (candidates2.length === 0) return null;
+
+  let choice = candidates2[0];
+  let reason = "";
+  if (maxDeficit > 0) {
+    candidates2.sort(
+      (a, b) =>
+        b.delta - a.delta || a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0),
+    );
+    choice = candidates2[0];
+    reason = `Materia ${choice.t.subject} · déficit · clase en ${choice.D} días · + cobertura`;
+  } else {
+    const maxDelta = Math.max(...candidates2.map((c) => c.delta));
+    if (maxDelta > 0) {
+      const pool = candidates2
+        .filter((c) => c.delta === maxDelta)
+        .sort((a, b) => a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0));
+      choice = pool[0];
+      reason = `Materia ${choice.t.subject} · déficit · clase en ${choice.D} días`;
+    } else {
+      candidates2.sort(
+        (a, b) =>
+          b.pressure - a.pressure || a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0),
+      );
+      choice = candidates2[0];
+      reason = `Materia ${choice.t.subject} · sin déficit · clase en ${choice.D} días`;
+      if (maxDeficit === 0 && (Date.now() - choice.t.lastTouched) / 3600000 >= PRACTICE_WINDOW_H) {
+        reason += " · + práctica ≤48 h";
+      }
+    }
+  }
+
+  return buildSuggestion(choice.t, slotMinutes, reason, {
+    delta: choice.delta,
+    D: choice.D,
+    R: choice.t.R,
+    cuota: choice.Q,
+    score: choice.pressure,
+  });
+}
+
+function buildSuggestion(
+  track: Track,
+  slotMinutes: number,
+  reason: string,
+  diag: { delta: number; D: number; R: number; cuota: number; score: number },
+) {
+  const plannedActs = Math.max(1, Math.floor(slotMinutes / track.avgMinPerAct));
+  const acts = Math.min(track.R, plannedActs);
+  const plannedMinutes = Math.round(acts * track.avgMinPerAct);
+  return {
+    trackSlug: track.slug,
+    nextIndex: track.nextIndex,
+    plannedActs: acts,
+    plannedMinutes,
+    reason,
+    diagnostics: { Δ: diag.delta, D: diag.D, R: diag.R, cuota: diag.cuota, score: diag.score },
+  };
+}
+
+export function registerProgress(trackSlug: string, minutesSpent?: number, nextIndex?: number) {
+  resetDayIfNeeded();
+  const track = tracks.find((t) => t.slug === trackSlug);
+  if (!track) return null;
+  track.lastTouched = Date.now();
+  track.doneActs += 1;
+  track.R = Math.max(0, track.R - 1);
+  track.nextIndex = typeof nextIndex === "number" ? nextIndex : track.nextIndex + 1;
+  if (minutesSpent) {
+    dayStats.minutesToday[track.subject] += minutesSpent;
+    track.avgMinPerAct = track.avgMinPerAct * 0.7 + minutesSpent * 0.3;
+  }
+  dayStats.actsToday[track.slug] = (dayStats.actsToday[track.slug] || 0) + 1;
+  return track;
+}

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -1,0 +1,82 @@
+export type Subject = "Álgebra" | "Cálculo" | "POO";
+
+export interface Track {
+  slug: string;
+  subject: Subject;
+  R: number; // remaining acts
+  classDate: string; // ISO date string
+  nextIndex: number;
+  lastTouched: number; // timestamp ms
+  avgMinPerAct: number;
+  active: boolean;
+  doneActs: number;
+}
+
+export const tracks: Track[] = [
+  {
+    slug: "algebra-t",
+    subject: "Álgebra",
+    R: 5,
+    classDate: "2025-08-17",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+  {
+    slug: "algebra-p",
+    subject: "Álgebra",
+    R: 6,
+    classDate: "2025-08-20",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+  {
+    slug: "poo-t",
+    subject: "POO",
+    R: 1,
+    classDate: "2025-08-18",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+  {
+    slug: "poo-p",
+    subject: "POO",
+    R: 1,
+    classDate: "2025-08-14",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+  {
+    slug: "calculo-p",
+    subject: "Cálculo",
+    R: 1,
+    classDate: "2025-08-18",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+  {
+    slug: "calculo-t",
+    subject: "Cálculo",
+    R: 1,
+    classDate: "2025-08-21",
+    nextIndex: 0,
+    lastTouched: 0,
+    avgMinPerAct: 50,
+    active: true,
+    doneActs: 0,
+  },
+];


### PR DESCRIPTION
## Summary
- add in-memory track and day statistics utilities
- implement scheduler with coverage, deficit and pressure rules
- expose POST /api/next and /api/progress endpoints

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt requires manual config)*

------
https://chatgpt.com/codex/tasks/task_e_689cf1b794148330b409a39d85f92729