### PR TITLE
feat: expose GET study tracking endpoints with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,18 @@ Continue building your app on:
 
 ## Seguimiento API
 
-This project now exposes two endpoints to assist with study planning:
+This project now exposes three **GET** endpoints to assist with study planning. All
+requests require a unique `reqId` and timestamp `ts` query parameter and respond
+with `Cache-Control: no-store`.
 
-- `POST /api/next`: receives `{ slotMinutes, currentTrackSlug?, forceSwitch? }` and
-  returns the next recommended track to study. Responds with `204` when there are
-  no pending tracks.
-- `POST /api/progress`: receives `{ trackSlug, minutesSpent?, nextIndex? }` to
-  register completed work on a track and returns the updated track along with the
-  next suggestion.
+- `GET /api/next`: query params `slotMinutes`, `currentTrack?`, `forceSwitch?` and
+  the required `reqId`, `ts`. It returns the next recommended track to study or
+  `204` when there are no pending tracks.
+- `GET /api/progress`: query params `track`, optional `minutes`, `nextIndex`, plus
+  `reqId` and `ts`. It registers completed work on a track, returning the updated
+  track and the next suggestion. Repeated `reqId` values are ignored.
+- `GET /api/tracks`: returns a summary of all tracks including quota, deficit and
+  days remaining.
 
 Each suggestion includes the planned acts and minutes together with a reason and
 diagnostic values (`Δ, D, R, cuota, score`) that follow the scheduling rules.

--- a/app/api/next/route.ts
+++ b/app/api/next/route.ts
@@ -1,14 +1,22 @@
 import { NextResponse } from "next/server";
 import { getNextSuggestion } from "../../../lib/scheduler";
 
-export async function POST(request: Request) {
-  const body = await request.json();
-  const { slotMinutes, currentTrackSlug, forceSwitch } = body;
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const reqId = url.searchParams.get("reqId");
+  const ts = url.searchParams.get("ts");
+  if (!reqId || !ts) {
+    return NextResponse.json({ error: "missing reqId or ts" }, { status: 400, headers: { "Cache-Control": "no-store" } });
+  }
+  const slotMinutes = parseInt(url.searchParams.get("slotMinutes") || "50", 10);
+  const currentTrack = url.searchParams.get("currentTrack") || undefined;
+  const forceSwitch = url.searchParams.get("forceSwitch") === "1";
   const result = getNextSuggestion({
-    slotMinutes: slotMinutes ?? 50,
-    currentTrackSlug,
+    slotMinutes,
+    currentTrackSlug: currentTrack,
     forceSwitch,
   });
-  if (!result) return new Response(null, { status: 204 });
-  return NextResponse.json(result);
+  if (!result)
+    return new Response(null, { status: 204, headers: { "Cache-Control": "no-store" } });
+  return NextResponse.json(result, { headers: { "Cache-Control": "no-store" } });
 }

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,15 +1,34 @@
 import { NextResponse } from "next/server";
 import { registerProgress, getNextSuggestion } from "../../../lib/scheduler";
+import { loadState, saveState } from "../../../lib/state";
 
-export async function POST(request: Request) {
-  const body = await request.json();
-  const { trackSlug, minutesSpent, nextIndex } = body;
-  const updatedTrack = registerProgress(trackSlug, minutesSpent, nextIndex);
-  if (!updatedTrack) return NextResponse.json({ error: "Not found" }, { status: 404 });
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const track = url.searchParams.get("track");
+  const minutes = url.searchParams.get("minutes");
+  const nextIndexParam = url.searchParams.get("nextIndex");
+  const reqId = url.searchParams.get("reqId");
+  const ts = url.searchParams.get("ts");
+  if (!track || !reqId || !ts) {
+    return NextResponse.json({ error: "missing parameters" }, { status: 400, headers: { "Cache-Control": "no-store" } });
+  }
+  const state = loadState();
+  if (state.processed[reqId]) {
+    return NextResponse.json(state.processed[reqId], { headers: { "Cache-Control": "no-store" } });
+  }
+  const minutesSpent = minutes ? parseInt(minutes, 10) : undefined;
+  const nextIndex = nextIndexParam ? parseInt(nextIndexParam, 10) : undefined;
+  const updatedTrack = registerProgress(track, minutesSpent, nextIndex);
+  if (!updatedTrack) {
+    return NextResponse.json({ error: "Not found" }, { status: 404, headers: { "Cache-Control": "no-store" } });
+  }
   const suggestedNext = getNextSuggestion({
     slotMinutes: minutesSpent ?? updatedTrack.avgMinPerAct,
-    currentTrackSlug: trackSlug,
+    currentTrackSlug: track,
     forceSwitch: false,
   });
-  return NextResponse.json({ updatedTrack, suggestedNext });
+  const response = { updatedTrack, suggestedNext };
+  state.processed[reqId] = response;
+  saveState();
+  return NextResponse.json(response, { headers: { "Cache-Control": "no-store" } });
 }

--- a/app/api/tracks/route.ts
+++ b/app/api/tracks/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { loadState, resetDayIfNeeded, saveState } from "../../../lib/state";
+
+function daysUntil(dateStr: string): number {
+  const today = new Date();
+  const target = new Date(dateStr);
+  const diff = Math.ceil((target.getTime() - today.getTime()) / 86400000);
+  return diff <= 0 ? 1 : diff;
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const reqId = url.searchParams.get("reqId");
+  const ts = url.searchParams.get("ts");
+  if (!reqId || !ts) {
+    return NextResponse.json({ error: "missing reqId or ts" }, { status: 400, headers: { "Cache-Control": "no-store" } });
+  }
+  const state = loadState();
+  resetDayIfNeeded(state.dayStats);
+  saveState();
+  const { tracks, dayStats } = state;
+  const rows = tracks.map((t) => {
+    const daysLeft = daysUntil(t.classDate);
+    const quota = Math.ceil(t.R / daysLeft);
+    const H = dayStats.actsToday[t.slug] || 0;
+    const deficit = quota - H;
+    return {
+      slug: t.slug,
+      subject: t.subject,
+      done: t.doneActs,
+      total: t.doneActs + t.R,
+      dueDate: t.classDate,
+      daysLeft,
+      quota,
+      deficit,
+      avgMinPerAct: t.avgMinPerAct,
+      R: t.R,
+    };
+  });
+  return NextResponse.json(rows, { headers: { "Cache-Control": "no-store" } });
+}

--- a/data/state.json
+++ b/data/state.json
@@ -1,0 +1,80 @@
+{
+  "tracks": [
+    {
+      "slug": "algebra-t",
+      "subject": "Álgebra",
+      "R": 5,
+      "classDate": "2025-08-17",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    },
+    {
+      "slug": "algebra-p",
+      "subject": "Álgebra",
+      "R": 6,
+      "classDate": "2025-08-20",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    },
+    {
+      "slug": "poo-t",
+      "subject": "POO",
+      "R": 1,
+      "classDate": "2025-08-18",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    },
+    {
+      "slug": "poo-p",
+      "subject": "POO",
+      "R": 1,
+      "classDate": "2025-08-14",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    },
+    {
+      "slug": "calculo-p",
+      "subject": "Cálculo",
+      "R": 1,
+      "classDate": "2025-08-18",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    },
+    {
+      "slug": "calculo-t",
+      "subject": "Cálculo",
+      "R": 1,
+      "classDate": "2025-08-21",
+      "nextIndex": 0,
+      "lastTouched": 0,
+      "avgMinPerAct": 50,
+      "active": true,
+      "doneActs": 0
+    }
+  ],
+  "dayStats": {
+    "date": "1970-01-01",
+    "actsToday": {},
+    "minutesToday": {
+      "Álgebra": 0,
+      "Cálculo": 0,
+      "POO": 0
+    }
+  },
+  "processed": {}
+}

--- a/lib/dayStats.ts
+++ b/lib/dayStats.ts
@@ -6,22 +6,24 @@ export interface DayStats {
   minutesToday: Record<Subject, number>;
 }
 
-export const dayStats: DayStats = {
-  date: new Date().toISOString().slice(0, 10),
-  actsToday: {},
-  minutesToday: {
-    "Álgebra": 0,
-    "Cálculo": 0,
-    POO: 0,
-  },
-};
+export function defaultDayStats(): DayStats {
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    actsToday: {},
+    minutesToday: {
+      "Álgebra": 0,
+      "Cálculo": 0,
+      POO: 0,
+    },
+  };
+}
 
-export function resetDayIfNeeded() {
+export function resetDayIfNeeded(ds: DayStats) {
   const today = new Date().toISOString().slice(0, 10);
-  if (dayStats.date !== today) {
-    dayStats.date = today;
-    dayStats.actsToday = {};
-    dayStats.minutesToday = {
+  if (ds.date !== today) {
+    ds.date = today;
+    ds.actsToday = {};
+    ds.minutesToday = {
       "Álgebra": 0,
       "Cálculo": 0,
       POO: 0,

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,5 +1,5 @@
-import { tracks, Track, Subject } from "./tracks";
-import { dayStats, resetDayIfNeeded } from "./dayStats";
+import { Track, Subject } from "./tracks";
+import { loadState, saveState, resetDayIfNeeded } from "./state";
 
 const B = 50; // cobertura mínima por materia
 const CMAX = 0.6; // 60%
@@ -31,10 +31,14 @@ interface SuggestParams {
 }
 
 export function getNextSuggestion(params: SuggestParams) {
-  resetDayIfNeeded();
+  const state = loadState();
+  resetDayIfNeeded(state.dayStats);
+  saveState();
   const { slotMinutes, currentTrackSlug, forceSwitch } = params;
 
   // compromiso de bloque
+  const tracks = state.tracks;
+  const dayStats = state.dayStats;
   if (currentTrackSlug && !forceSwitch) {
     const current = tracks.find((t) => t.slug === currentTrackSlug);
     if (current && current.active && current.R > 0) {
@@ -159,7 +163,10 @@ function buildSuggestion(
 }
 
 export function registerProgress(trackSlug: string, minutesSpent?: number, nextIndex?: number) {
-  resetDayIfNeeded();
+  const state = loadState();
+  resetDayIfNeeded(state.dayStats);
+  const tracks = state.tracks;
+  const dayStats = state.dayStats;
   const track = tracks.find((t) => t.slug === trackSlug);
   if (!track) return null;
   track.lastTouched = Date.now();
@@ -171,5 +178,6 @@ export function registerProgress(trackSlug: string, minutesSpent?: number, nextI
     track.avgMinPerAct = track.avgMinPerAct * 0.7 + minutesSpent * 0.3;
   }
   dayStats.actsToday[track.slug] = (dayStats.actsToday[track.slug] || 0) + 1;
+  saveState();
   return track;
 }

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import { Track, initialTracks } from "./tracks";
+import { DayStats, defaultDayStats, resetDayIfNeeded } from "./dayStats";
+
+export interface State {
+  tracks: Track[];
+  dayStats: DayStats;
+  processed: Record<string, any>;
+}
+
+const STATE_PATH = path.join(process.cwd(), "data/state.json");
+
+let state: State | null = null;
+
+function loadFromDisk(): State {
+  try {
+    const raw = fs.readFileSync(STATE_PATH, "utf8");
+    return JSON.parse(raw) as State;
+  } catch {
+    return {
+      tracks: initialTracks.map((t) => ({ ...t })),
+      dayStats: defaultDayStats(),
+      processed: {},
+    };
+  }
+}
+
+export function loadState(): State {
+  if (!state) {
+    state = loadFromDisk();
+  }
+  return state;
+}
+
+export function saveState() {
+  if (!state) return;
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+export { resetDayIfNeeded };

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -12,7 +12,7 @@ export interface Track {
   doneActs: number;
 }
 
-export const tracks: Track[] = [
+export const initialTracks: Track[] = [
   {
     slug: "algebra-t",
     subject: "Álgebra",


### PR DESCRIPTION
## Summary
- switch study planner API to GET endpoints with `reqId`/`ts` for idempotent calls
- add JSON-based state persistence and request deduplication
- expose `/api/tracks` summary endpoint and document new API usage

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689cf869ba548330897434818f4a6249