### PR TITLE
Implement GET scheduling API with JSON state

### DIFF
--- a/app/api/next/route.ts
+++ b/app/api/next/route.ts
@@ -1,14 +1,30 @@
-import { NextResponse } from "next/server";
-import { getNextSuggestion } from "../../../lib/scheduler";
+import { NextResponse } from "next/server"
+import { getNextSuggestion } from "../../../lib/scheduler"
 
-export async function POST(request: Request) {
-  const body = await request.json();
-  const { slotMinutes, currentTrackSlug, forceSwitch } = body;
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const reqId = searchParams.get("reqId")
+  const ts = searchParams.get("ts")
+  if (!reqId || !ts) {
+    return new NextResponse("missing reqId or ts", {
+      status: 400,
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+  const slotMinutes = parseInt(searchParams.get("slotMinutes") || "50", 10)
+  const currentTrack = searchParams.get("currentTrack") || undefined
+  const forceSwitch = searchParams.get("forceSwitch") === "1"
   const result = getNextSuggestion({
-    slotMinutes: slotMinutes ?? 50,
-    currentTrackSlug,
+    slotMinutes,
+    currentTrackSlug: currentTrack,
     forceSwitch,
-  });
-  if (!result) return new Response(null, { status: 204 });
-  return NextResponse.json(result);
+  })
+  if (!result)
+    return new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
+    })
+  return NextResponse.json(result, {
+    headers: { "Cache-Control": "no-store" },
+  })
 }

--- a/app/api/progress/route.ts
+++ b/app/api/progress/route.ts
@@ -1,15 +1,54 @@
-import { NextResponse } from "next/server";
-import { registerProgress, getNextSuggestion } from "../../../lib/scheduler";
+import { NextResponse } from "next/server"
+import { registerProgress, getNextSuggestion } from "../../../lib/scheduler"
+import { tracks } from "../../../lib/tracks"
 
-export async function POST(request: Request) {
-  const body = await request.json();
-  const { trackSlug, minutesSpent, nextIndex } = body;
-  const updatedTrack = registerProgress(trackSlug, minutesSpent, nextIndex);
-  if (!updatedTrack) return NextResponse.json({ error: "Not found" }, { status: 404 });
+const processed = new Map<string, any>()
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const reqId = searchParams.get("reqId")
+  const ts = searchParams.get("ts")
+  const trackSlug = searchParams.get("track")
+  if (!reqId || !ts || !trackSlug) {
+    return new NextResponse("missing params", {
+      status: 400,
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+  if (processed.has(reqId)) {
+    return NextResponse.json(processed.get(reqId), {
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+
+  const track = tracks.find((t) => t.slug === trackSlug)
+  if (!track) {
+    return new NextResponse("track not found", {
+      status: 400,
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+  if (track.R <= 0) {
+    return new NextResponse("vector complete", {
+      status: 409,
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+
+  const minutesParam = searchParams.get("minutes")
+  const minutes = minutesParam ? parseInt(minutesParam, 10) : undefined
+  const nextIndexParam = searchParams.get("nextIndex")
+  const nextIndex = nextIndexParam ? parseInt(nextIndexParam, 10) : undefined
+
+  const updatedTrack = registerProgress(trackSlug, minutes, nextIndex)
   const suggestedNext = getNextSuggestion({
-    slotMinutes: minutesSpent ?? updatedTrack.avgMinPerAct,
+    slotMinutes: minutes ?? updatedTrack.avgMinPerAct,
     currentTrackSlug: trackSlug,
     forceSwitch: false,
-  });
-  return NextResponse.json({ updatedTrack, suggestedNext });
+  })
+  const response = { updatedTrack, suggestedNext }
+  processed.set(reqId, response)
+  return NextResponse.json(response, {
+    headers: { "Cache-Control": "no-store" },
+  })
 }

--- a/app/api/tracks/route.ts
+++ b/app/api/tracks/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server"
+import { tracks } from "../../../lib/tracks"
+import { dayStats } from "../../../lib/dayStats"
+import { daysUntil } from "../../../lib/scheduler"
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const reqId = searchParams.get("reqId")
+  const ts = searchParams.get("ts")
+  if (!reqId || !ts) {
+    return new NextResponse("missing reqId or ts", {
+      status: 400,
+      headers: { "Cache-Control": "no-store" },
+    })
+  }
+  const summary = tracks.map((t) => {
+    const daysLeft = daysUntil(t.classDate)
+    const quota = Math.ceil(t.R / Math.max(daysLeft, 1))
+    const H = dayStats.actsToday[t.slug] || 0
+    const deficit = quota - H
+    return {
+      slug: t.slug,
+      subject: t.subject,
+      done: t.doneActs,
+      total: t.doneActs + t.R,
+      remain: t.R,
+      dueDate: t.classDate,
+      daysLeft,
+      quota,
+      deficit,
+      avgMinPerAct: t.avgMinPerAct,
+    }
+  })
+  return NextResponse.json(summary, {
+    headers: { "Cache-Control": "no-store" },
+  })
+}

--- a/data/dayStats.json
+++ b/data/dayStats.json
@@ -1,0 +1,9 @@
+{
+  "date": "1970-01-01",
+  "actsToday": {},
+  "minutesToday": {
+    "Álgebra": 0,
+    "Cálculo": 0,
+    "POO": 0
+  }
+}

--- a/data/tracks.json
+++ b/data/tracks.json
@@ -1,0 +1,68 @@
+[
+  {
+    "slug": "algebra-T",
+    "subject": "Álgebra",
+    "R": 5,
+    "classDate": "2025-08-17",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  },
+  {
+    "slug": "algebra-P",
+    "subject": "Álgebra",
+    "R": 6,
+    "classDate": "2025-08-20",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  },
+  {
+    "slug": "poo-T",
+    "subject": "POO",
+    "R": 1,
+    "classDate": "2025-08-18",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  },
+  {
+    "slug": "poo-P",
+    "subject": "POO",
+    "R": 1,
+    "classDate": "2025-08-14",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  },
+  {
+    "slug": "calculo-P",
+    "subject": "Cálculo",
+    "R": 1,
+    "classDate": "2025-08-18",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  },
+  {
+    "slug": "calculo-T",
+    "subject": "Cálculo",
+    "R": 1,
+    "classDate": "2025-08-21",
+    "nextIndex": 0,
+    "lastTouched": 0,
+    "avgMinPerAct": 50,
+    "active": true,
+    "doneActs": 0
+  }
+]

--- a/lib/dayStats.ts
+++ b/lib/dayStats.ts
@@ -1,30 +1,33 @@
-import { Subject } from "./tracks";
+import fs from "fs"
+import path from "path"
+import { Subject } from "./tracks"
 
 export interface DayStats {
-  date: string; // YYYY-MM-DD
-  actsToday: Record<string, number>;
-  minutesToday: Record<Subject, number>;
+  date: string // YYYY-MM-DD
+  actsToday: Record<string, number>
+  minutesToday: Record<Subject, number>
 }
 
-export const dayStats: DayStats = {
-  date: new Date().toISOString().slice(0, 10),
-  actsToday: {},
-  minutesToday: {
-    "Álgebra": 0,
-    "Cálculo": 0,
-    POO: 0,
-  },
-};
+const dayStatsFile = path.join(process.cwd(), "data", "dayStats.json")
+
+export const dayStats: DayStats = JSON.parse(
+  fs.readFileSync(dayStatsFile, "utf-8")
+)
+
+export function saveDayStats() {
+  fs.writeFileSync(dayStatsFile, JSON.stringify(dayStats, null, 2))
+}
 
 export function resetDayIfNeeded() {
-  const today = new Date().toISOString().slice(0, 10);
+  const today = new Date().toISOString().slice(0, 10)
   if (dayStats.date !== today) {
-    dayStats.date = today;
-    dayStats.actsToday = {};
+    dayStats.date = today
+    dayStats.actsToday = {}
     dayStats.minutesToday = {
       "Álgebra": 0,
       "Cálculo": 0,
       POO: 0,
-    };
+    }
+    saveDayStats()
   }
 }

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -1,175 +1,203 @@
-import { tracks, Track, Subject } from "./tracks";
-import { dayStats, resetDayIfNeeded } from "./dayStats";
+import { tracks, Track, Subject, saveTracks } from "./tracks"
+import { dayStats, resetDayIfNeeded, saveDayStats } from "./dayStats"
 
-const B = 50; // cobertura mínima por materia
-const CMAX = 0.6; // 60%
-const PRACTICE_WINDOW_H = 48; // ventana de práctica
+const B = 50 // cobertura mínima por materia
+const CMAX = 0.6 // 60%
+const PRACTICE_WINDOW_H = 48 // ventana de práctica
 
-function daysUntil(dateStr: string): number {
-  const today = new Date();
-  const target = new Date(dateStr);
-  const diff = Math.ceil((target.getTime() - today.getTime()) / 86400000);
-  return diff <= 0 ? 1 : diff;
+export function daysUntil(dateStr: string): number {
+  const today = new Date()
+  const target = new Date(dateStr)
+  const diff = Math.ceil((target.getTime() - today.getTime()) / 86400000)
+  return diff <= 0 ? 1 : diff
 }
 
 function eventBonus(D: number): number {
-  if (D <= 1) return 1; // fuerte ≤24h
-  if (D <= 3) return 0.5; // moderado ≤72h
-  return 0;
+  if (D <= 1) return 1 // fuerte ≤24h
+  if (D <= 3) return 0.5 // moderado ≤72h
+  return 0
 }
 
 function cooldownBonus(lastTouched: number): number {
-  if (!lastTouched) return 0.1;
-  const days = (Date.now() - lastTouched) / 86400000;
-  return days * 0.01;
+  if (!lastTouched) return 0.1
+  const days = (Date.now() - lastTouched) / 86400000
+  return days * 0.01
+}
+
+function trackType(slug: string): string {
+  return slug.toLowerCase().endsWith("-p") ? "Práctica" : "Teoría"
+}
+
+function label(t: Track): string {
+  return `${t.subject} ${trackType(t.slug)}`
 }
 
 interface SuggestParams {
-  slotMinutes: number;
-  currentTrackSlug?: string;
-  forceSwitch?: boolean;
+  slotMinutes: number
+  currentTrackSlug?: string
+  forceSwitch?: boolean
 }
 
 export function getNextSuggestion(params: SuggestParams) {
-  resetDayIfNeeded();
-  const { slotMinutes, currentTrackSlug, forceSwitch } = params;
+  resetDayIfNeeded()
+  const { slotMinutes, currentTrackSlug, forceSwitch } = params
 
   // compromiso de bloque
   if (currentTrackSlug && !forceSwitch) {
-    const current = tracks.find((t) => t.slug === currentTrackSlug);
+    const current = tracks.find((t) => t.slug === currentTrackSlug)
     if (current && current.active && current.R > 0) {
       const emergency = tracks.some(
-        (t) => t.slug !== currentTrackSlug && t.active && t.R > 0 && daysUntil(t.classDate) <= 1,
-      );
+        (t) =>
+          t.slug !== currentTrackSlug && t.active && t.R > 0 && daysUntil(t.classDate) <= 1,
+      )
       if (!emergency) {
-        const D = daysUntil(current.classDate);
-        const Q = Math.ceil(current.R / D);
-        const H = dayStats.actsToday[current.slug] || 0;
-        const delta = Q - H;
-        const pressure = current.R / D + eventBonus(D) + cooldownBonus(current.lastTouched);
-        return buildSuggestion(current, slotMinutes, `Materia ${current.subject} · continuar bloque · clase en ${D} días`, {
-          delta,
-          D,
-          R: current.R,
-          cuota: Q,
-          score: pressure,
-        });
+        const D = daysUntil(current.classDate)
+        const Q = Math.ceil(current.R / D)
+        const H = dayStats.actsToday[current.slug] || 0
+        const delta = Q - H
+        const pressure = current.R / D + eventBonus(D) + cooldownBonus(current.lastTouched)
+        return buildSuggestion(
+          current,
+          slotMinutes,
+          `${label(current)} · continuar bloque · clase en ${D} día${D === 1 ? "" : "s"}`,
+          { deficit: delta, daysLeft: D, remain: current.R, quota: Q, score: pressure },
+        )
       }
     }
   }
 
-  let candidates = tracks.filter((t) => t.active && t.R > 0);
-  if (candidates.length === 0) return null;
+  let candidates = tracks.filter((t) => t.active && t.R > 0)
+  if (candidates.length === 0) return null
 
   const subjectDeficits: Record<Subject, number> = {
-    "Álgebra": Math.max(0, B - dayStats.minutesToday["Álgebra"]),
-    "Cálculo": Math.max(0, B - dayStats.minutesToday["Cálculo"]),
+    Álgebra: Math.max(0, B - dayStats.minutesToday["Álgebra"]),
+    Cálculo: Math.max(0, B - dayStats.minutesToday["Cálculo"]),
     POO: Math.max(0, B - dayStats.minutesToday.POO),
-  };
-  const maxDeficit = Math.max(...Object.values(subjectDeficits));
-  let coverageSubjects: Subject[] = [];
+  }
+  const maxDeficit = Math.max(...Object.values(subjectDeficits))
+  let coverageSubjects: Subject[] = []
   if (maxDeficit > 0) {
     coverageSubjects = (Object.keys(subjectDeficits) as Subject[]).filter(
       (s) => subjectDeficits[s] === maxDeficit,
-    );
-    candidates = candidates.filter((t) => coverageSubjects.includes(t.subject));
+    )
+    candidates = candidates.filter((t) => coverageSubjects.includes(t.subject))
   }
 
   const evaluated = candidates.map((t) => {
-    const D = daysUntil(t.classDate);
-    const Q = Math.ceil(t.R / D);
-    const H = dayStats.actsToday[t.slug] || 0;
-    const delta = Q - H;
-    const pressure = t.R / D + eventBonus(D) + cooldownBonus(t.lastTouched);
-    return { t, D, Q, H, delta, pressure };
-  });
+    const D = daysUntil(t.classDate)
+    const Q = Math.ceil(t.R / D)
+    const H = dayStats.actsToday[t.slug] || 0
+    const delta = Q - H
+    const pressure = t.R / D + eventBonus(D) + cooldownBonus(t.lastTouched)
+    return { t, D, Q, H, delta, pressure }
+  })
 
-  const totalMinutes = Object.values(dayStats.minutesToday).reduce((a, b) => a + b, 0);
-  const overCmax: Subject[] = [];
+  const totalMinutes = Object.values(dayStats.minutesToday).reduce((a, b) => a + b, 0)
+  const overCmax: Subject[] = []
   if (totalMinutes > 0) {
-    (Object.keys(dayStats.minutesToday) as Subject[]).forEach((s) => {
-      if (dayStats.minutesToday[s] / totalMinutes > CMAX) overCmax.push(s);
-    });
+    ;(Object.keys(dayStats.minutesToday) as Subject[]).forEach((s) => {
+      if (dayStats.minutesToday[s] / totalMinutes > CMAX) overCmax.push(s)
+    })
   }
 
   const candidates2 = evaluated.filter((e) => {
     if (overCmax.includes(e.t.subject) && !(e.D <= 1 && e.t.R > 0)) {
-      return false;
+      return false
     }
-    return true;
-  });
-  if (candidates2.length === 0) return null;
+    return true
+  })
+  if (candidates2.length === 0) return null
 
-  let choice = candidates2[0];
-  let reason = "";
+  let choice = candidates2[0]
+  let reason = ""
   if (maxDeficit > 0) {
     candidates2.sort(
       (a, b) =>
         b.delta - a.delta || a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0),
-    );
-    choice = candidates2[0];
-    reason = `Materia ${choice.t.subject} · déficit · clase en ${choice.D} días · + cobertura`;
+    )
+    choice = candidates2[0]
+    if (choice.delta > 0) {
+      reason = `${label(choice.t)} · déficit ${choice.delta} · clase en ${choice.D} día${
+        choice.D === 1 ? "" : "s"
+      }`
+    } else {
+      reason = `${label(choice.t)} · sin déficit · clase en ${choice.D} día${
+        choice.D === 1 ? "" : "s"
+      } · + cobertura ${choice.t.subject}`
+    }
   } else {
-    const maxDelta = Math.max(...candidates2.map((c) => c.delta));
+    const maxDelta = Math.max(...candidates2.map((c) => c.delta))
     if (maxDelta > 0) {
       const pool = candidates2
         .filter((c) => c.delta === maxDelta)
-        .sort((a, b) => a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0));
-      choice = pool[0];
-      reason = `Materia ${choice.t.subject} · déficit · clase en ${choice.D} días`;
+        .sort((a, b) => a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0))
+      choice = pool[0]
+      reason = `${label(choice.t)} · déficit ${choice.delta} · clase en ${choice.D} día${
+        choice.D === 1 ? "" : "s"
+      }`
     } else {
       candidates2.sort(
         (a, b) =>
           b.pressure - a.pressure || a.D - b.D || (a.t.lastTouched || 0) - (b.t.lastTouched || 0),
-      );
-      choice = candidates2[0];
-      reason = `Materia ${choice.t.subject} · sin déficit · clase en ${choice.D} días`;
+      )
+      choice = candidates2[0]
+      reason = `${label(choice.t)} · sin déficit · clase en ${choice.D} día${
+        choice.D === 1 ? "" : "s"
+      }`
       if (maxDeficit === 0 && (Date.now() - choice.t.lastTouched) / 3600000 >= PRACTICE_WINDOW_H) {
-        reason += " · + práctica ≤48 h";
+        reason += " · + práctica ≤48 h"
       }
     }
   }
 
   return buildSuggestion(choice.t, slotMinutes, reason, {
-    delta: choice.delta,
-    D: choice.D,
-    R: choice.t.R,
-    cuota: choice.Q,
+    deficit: choice.delta,
+    daysLeft: choice.D,
+    remain: choice.t.R,
+    quota: choice.Q,
     score: choice.pressure,
-  });
+  })
 }
 
 function buildSuggestion(
   track: Track,
   slotMinutes: number,
   reason: string,
-  diag: { delta: number; D: number; R: number; cuota: number; score: number },
+  diag: { deficit: number; daysLeft: number; remain: number; quota: number; score: number },
 ) {
-  const plannedActs = Math.max(1, Math.floor(slotMinutes / track.avgMinPerAct));
-  const acts = Math.min(track.R, plannedActs);
-  const plannedMinutes = Math.round(acts * track.avgMinPerAct);
+  const plannedActs = Math.max(1, Math.floor(slotMinutes / track.avgMinPerAct))
+  const acts = Math.min(track.R, plannedActs)
+  const plannedMinutes = Math.round(acts * track.avgMinPerAct)
   return {
     trackSlug: track.slug,
     nextIndex: track.nextIndex,
     plannedActs: acts,
     plannedMinutes,
     reason,
-    diagnostics: { Δ: diag.delta, D: diag.D, R: diag.R, cuota: diag.cuota, score: diag.score },
-  };
+    diagnostics: {
+      deficit: diag.deficit,
+      daysLeft: diag.daysLeft,
+      remain: diag.remain,
+      quota: diag.quota,
+      score: diag.score,
+    },
+  }
 }
 
 export function registerProgress(trackSlug: string, minutesSpent?: number, nextIndex?: number) {
-  resetDayIfNeeded();
-  const track = tracks.find((t) => t.slug === trackSlug);
-  if (!track) return null;
-  track.lastTouched = Date.now();
-  track.doneActs += 1;
-  track.R = Math.max(0, track.R - 1);
-  track.nextIndex = typeof nextIndex === "number" ? nextIndex : track.nextIndex + 1;
+  resetDayIfNeeded()
+  const track = tracks.find((t) => t.slug === trackSlug)
+  if (!track) return null
+  track.lastTouched = Date.now()
+  track.doneActs += 1
+  track.R = Math.max(0, track.R - 1)
+  track.nextIndex = typeof nextIndex === "number" ? nextIndex : track.nextIndex + 1
   if (minutesSpent) {
-    dayStats.minutesToday[track.subject] += minutesSpent;
-    track.avgMinPerAct = track.avgMinPerAct * 0.7 + minutesSpent * 0.3;
+    dayStats.minutesToday[track.subject] += minutesSpent
+    track.avgMinPerAct = track.avgMinPerAct * 0.7 + minutesSpent * 0.3
   }
-  dayStats.actsToday[track.slug] = (dayStats.actsToday[track.slug] || 0) + 1;
-  return track;
+  dayStats.actsToday[track.slug] = (dayStats.actsToday[track.slug] || 0) + 1
+  saveTracks()
+  saveDayStats()
+  return track
 }

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -1,82 +1,26 @@
-export type Subject = "Álgebra" | "Cálculo" | "POO";
+import fs from "fs"
+import path from "path"
+
+export type Subject = "Álgebra" | "Cálculo" | "POO"
 
 export interface Track {
-  slug: string;
-  subject: Subject;
-  R: number; // remaining acts
-  classDate: string; // ISO date string
-  nextIndex: number;
-  lastTouched: number; // timestamp ms
-  avgMinPerAct: number;
-  active: boolean;
-  doneActs: number;
+  slug: string
+  subject: Subject
+  R: number // remaining acts
+  classDate: string // ISO date string
+  nextIndex: number
+  lastTouched: number // timestamp ms
+  avgMinPerAct: number
+  active: boolean
+  doneActs: number
 }
 
-export const tracks: Track[] = [
-  {
-    slug: "algebra-t",
-    subject: "Álgebra",
-    R: 5,
-    classDate: "2025-08-17",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-  {
-    slug: "algebra-p",
-    subject: "Álgebra",
-    R: 6,
-    classDate: "2025-08-20",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-  {
-    slug: "poo-t",
-    subject: "POO",
-    R: 1,
-    classDate: "2025-08-18",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-  {
-    slug: "poo-p",
-    subject: "POO",
-    R: 1,
-    classDate: "2025-08-14",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-  {
-    slug: "calculo-p",
-    subject: "Cálculo",
-    R: 1,
-    classDate: "2025-08-18",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-  {
-    slug: "calculo-t",
-    subject: "Cálculo",
-    R: 1,
-    classDate: "2025-08-21",
-    nextIndex: 0,
-    lastTouched: 0,
-    avgMinPerAct: 50,
-    active: true,
-    doneActs: 0,
-  },
-];
+const tracksFile = path.join(process.cwd(), "data", "tracks.json")
+
+export const tracks: Track[] = JSON.parse(
+  fs.readFileSync(tracksFile, "utf-8")
+)
+
+export function saveTracks() {
+  fs.writeFileSync(tracksFile, JSON.stringify(tracks, null, 2))
+}


### PR DESCRIPTION
## Summary
- store tracks and daily stats in JSON files and persist updates
- expose GET endpoints for next suggestion, progress recording with idempotency, and tracks summary
- adjust scheduling logic with clearer reasons and diagnostics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_689cf869ba548330897434818f4a6249