### PR TITLE
feat: persist events to disk

### DIFF
--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { NextResponse } from "next/server"
-import { events } from "../../../../lib/events"
+import { loadEvents } from "../../../../lib/events"
 
 export async function GET(
   _request: Request,
@@ -14,6 +14,7 @@ export async function GET(
     ({ id } = context.params)
   }
 
+  const events = loadEvents()
   const event = events.find((e) => e.id === id)
 
   if (event) return NextResponse.json(event)

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 import { NextResponse } from "next/server"
-import { events, Event } from "../../../lib/events"
+import { loadEvents, saveEvents, Event } from "../../../lib/events"
 
 export async function GET(request: Request) {
+  const events = loadEvents()
   const { searchParams } = new URL(request.url)
   const id = searchParams.get("id")
   if (id) {
@@ -16,6 +17,7 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const body = await request.json()
   const { action, event } = body
+  const events = loadEvents()
 
   switch (action) {
     case "add":
@@ -24,6 +26,7 @@ export async function POST(request: Request) {
         completed: event.completed ?? 0,
         total: event.total ?? 0,
       })
+      saveEvents(events)
       return NextResponse.json({ status: "added" })
 
     case "edit":
@@ -33,12 +36,16 @@ export async function POST(request: Request) {
           ...events[index],
           ...event,
         }
+        saveEvents(events)
       }
       return NextResponse.json({ status: "updated" })
 
     case "delete":
       const idx = events.findIndex((e) => e.id === event.id)
-      if (idx !== -1) events.splice(idx, 1)
+      if (idx !== -1) {
+        events.splice(idx, 1)
+        saveEvents(events)
+      }
       return NextResponse.json({ status: "deleted" })
 
     default:

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "1",
+    "date": "2025-08-17",
+    "name": "T - Álgebra",
+    "importance": 2,
+    "content": "5.1 a 5.6",
+    "completed": 1,
+    "total": 6,
+    "daysRemaining": 0,
+    "isEditing": false
+  },
+  {
+    "id": "2",
+    "date": "2025-08-20",
+    "name": "P - Álgebra",
+    "importance": 2,
+    "content": "5.1 a 5.6",
+    "completed": 1,
+    "total": 6,
+    "daysRemaining": 0,
+    "isEditing": false
+  },
+  {
+    "id": "3",
+    "date": "2025-08-18",
+    "name": "T - Poo",
+    "importance": 2,
+    "content": "U1",
+    "completed": 0,
+    "total": 1,
+    "daysRemaining": 0,
+    "isEditing": false
+  },
+  {
+    "id": "4",
+    "date": "2025-08-14",
+    "name": "P - Poo",
+    "importance": 2,
+    "content": "U1",
+    "completed": 0,
+    "total": 1,
+    "daysRemaining": 0,
+    "isEditing": false
+  },
+  {
+    "id": "5",
+    "date": "2025-08-18",
+    "name": "P - Cálculo",
+    "importance": 2,
+    "content": "4.1 a 4.3",
+    "completed": 0,
+    "total": 1,
+    "daysRemaining": 0,
+    "isEditing": false
+  },
+  {
+    "id": "6",
+    "date": "2025-08-21",
+    "name": "T - Cálculo",
+    "importance": 2,
+    "content": "4.1 a 4.3",
+    "completed": 0,
+    "total": 1,
+    "daysRemaining": 0,
+    "isEditing": false
+  }
+]

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,4 +1,7 @@
-  export interface Event {
+import fs from "fs"
+import path from "path"
+
+export interface Event {
   id: string
   date: string
   name: string
@@ -10,7 +13,10 @@
   isEditing: boolean
 }
 
-export let events: Event[] = [
+const DATA_DIR = path.join(process.cwd(), "data")
+const FILE = path.join(DATA_DIR, "events.json")
+
+const defaultEvents: Event[] = [
   {
     id: "1",
     date: "2025-08-17",
@@ -78,3 +84,23 @@ export let events: Event[] = [
     isEditing: false,
   },
 ]
+
+export function loadEvents(): Event[] {
+  try {
+    if (!fs.existsSync(FILE)) {
+      fs.mkdirSync(DATA_DIR, { recursive: true })
+      fs.writeFileSync(FILE, JSON.stringify(defaultEvents, null, 2))
+      return defaultEvents
+    }
+    const raw = fs.readFileSync(FILE, "utf8")
+    return JSON.parse(raw)
+  } catch {
+    return defaultEvents
+  }
+}
+
+export function saveEvents(events: Event[]) {
+  fs.mkdirSync(DATA_DIR, { recursive: true })
+  fs.writeFileSync(FILE, JSON.stringify(events, null, 2))
+}
+


### PR DESCRIPTION
## Summary
- persist events using data/events.json file
- update events API to load and save to disk
- seed repository with default events data

## Testing
- ⚠️ `pnpm lint` *(failed: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a96502988330bd9ebb6a37d0519b