### PR TITLE
feat: support configurable data directory

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -14,7 +14,7 @@ export interface Event {
 }
 
 const DATA_DIR = path.resolve(
-  process.env.EVENTS_DIR || path.join(process.cwd(), "data"),
+  process.env.EVENTS_DIR || process.env.DATA_DIR || "/gestor/system",
 )
 const FILE = path.join(DATA_DIR, "events.json")
 

--- a/lib/materias.ts
+++ b/lib/materias.ts
@@ -13,7 +13,7 @@ export interface MateriasState {
   materias: Materia[];
 }
 
-const DATA_DIR = path.join(process.cwd(), 'data');
+const DATA_DIR = path.resolve(process.env.DATA_DIR || '/gestor/system');
 const FILE = path.join(DATA_DIR, 'materias.json');
 
 function defaultState(): MateriasState {
@@ -29,9 +29,9 @@ function defaultState(): MateriasState {
 export function loadMaterias(): MateriasState {
   try {
     if (!fs.existsSync(FILE)) {
-      fs.mkdirSync(DATA_DIR, { recursive: true });
+      fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
       const init = defaultState();
-      fs.writeFileSync(FILE, JSON.stringify(init, null, 2));
+      fs.writeFileSync(FILE, JSON.stringify(init, null, 2), { mode: 0o600 });
       return init;
     }
     const raw = fs.readFileSync(FILE, 'utf8');
@@ -42,8 +42,8 @@ export function loadMaterias(): MateriasState {
 }
 
 export function saveMaterias(state: MateriasState) {
-  fs.mkdirSync(DATA_DIR, { recursive: true });
-  fs.writeFileSync(FILE, JSON.stringify(state, null, 2));
+  fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(FILE, JSON.stringify(state, null, 2), { mode: 0o600 });
 }
 
 export function daysLeft(fecha: string): number {

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -5,7 +5,7 @@ export interface Settings {
   dailyLimit: number;
 }
 
-const DATA_DIR = path.join(process.cwd(), 'data');
+const DATA_DIR = path.resolve(process.env.DATA_DIR || '/gestor/system');
 const SETTINGS_FILE = path.join(DATA_DIR, 'settings.json');
 
 const defaultSettings: Settings = { dailyLimit: 100 };
@@ -13,8 +13,10 @@ const defaultSettings: Settings = { dailyLimit: 100 };
 export function loadSettings(): Settings {
   try {
     if (!fs.existsSync(SETTINGS_FILE)) {
-      fs.mkdirSync(DATA_DIR, { recursive: true });
-      fs.writeFileSync(SETTINGS_FILE, JSON.stringify(defaultSettings, null, 2));
+      fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(SETTINGS_FILE, JSON.stringify(defaultSettings, null, 2), {
+        mode: 0o600,
+      });
       return defaultSettings;
     }
     const raw = fs.readFileSync(SETTINGS_FILE, 'utf8');

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -10,7 +10,7 @@ export interface State {
   requestCounts: Record<string, { date: string; count: number }>;
 }
 
-const DATA_DIR = path.join(process.cwd(), 'data');
+const DATA_DIR = path.resolve(process.env.DATA_DIR || '/gestor/system');
 const STATE_FILE = path.join(DATA_DIR, 'state.json');
 
 function createInitialState(): State {
@@ -91,9 +91,11 @@ function createInitialState(): State {
 export function loadState(): State {
   try {
     if (!fs.existsSync(STATE_FILE)) {
-      fs.mkdirSync(DATA_DIR, { recursive: true });
+      fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
       const initial = createInitialState();
-      fs.writeFileSync(STATE_FILE, JSON.stringify(initial, null, 2));
+      fs.writeFileSync(STATE_FILE, JSON.stringify(initial, null, 2), {
+        mode: 0o600,
+      });
       return initial;
     }
     const raw = fs.readFileSync(STATE_FILE, 'utf8');
@@ -105,8 +107,10 @@ export function loadState(): State {
 }
 
 export function saveState(state: State) {
-  fs.mkdirSync(DATA_DIR, { recursive: true });
-  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  fs.mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), {
+    mode: 0o600,
+  });
 }
 
 export function incrementRequestCount(endpoint: string): boolean {


### PR DESCRIPTION
## Summary
- allow data persistence under configurable directory, defaulting to `/gestor/system`
- ensure stored files use restricted read/write permissions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ab11103b4483308a61d9174d94eb80